### PR TITLE
Add Telegram bot commands to PBMon

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It has the following functions:
 - A dashboard for viewing trading performance.
 - An interface to CoinMarketCap for selecting and filtering coins.
 - Installing and updating your VPS with just a few clicks.
+- Telegram commands to change instance modes (panic, graceful stop, normal).
 - And much more to easily manage Passivbot.
 
 ### Requirements
@@ -216,6 +217,7 @@ Add start.bat to Windows Task Scheduler and use Trigger "At system startup"
 - Using fragments for speedup GUI
 - Support for GateIO
 - Send Telegram Messages on Bot errors
+- Telegram commands for risk management
 - logarithmic view of backtests
 - TWE and WE view on backtests v7
 - Update to streamlit v1.44

--- a/pbgui_help.py
+++ b/pbgui_help.py
@@ -1302,6 +1302,14 @@ pbmon_telegram_chat_id = """
     Your Telegram Chat ID
     ```"""
 
+pbmon_telegram_bot = """
+    PBMon listens for Telegram commands for risk management.
+    Available commands:
+    `/panic <user> <symbol> <market>` - set panic mode
+    `/graceful_stop <user> <symbol> <market>` - set graceful_stop mode
+    `/normal <user> <symbol> <market>` - set normal mode
+    ```"""
+
 archive_name = """
     ```
     Name of the archive


### PR DESCRIPTION
## Summary
- extend PBMon with optional Telegram bot for risk management
- allow panic/graceful stop/normal commands to modify instance modes
- update README with new feature highlights
- document Telegram bot usage in help text

## Testing
- `python -m py_compile PBMon.py pbgui_help.py`

------
https://chatgpt.com/codex/tasks/task_b_683ac1747034832382a254e8f3f9799b