### PR TITLE
Fix telegram bot wait call

### DIFF
--- a/PBMon.py
+++ b/PBMon.py
@@ -120,7 +120,7 @@ class PBMon():
             await self.bot_application.initialize()
             await self.bot_application.start()
             await self.bot_application.updater.start_polling()
-            await self.bot_application.updater.wait_closed()
+            await self.bot_application.updater.wait()
         finally:
             await self.bot_application.stop()
             await self.bot_application.shutdown()


### PR DESCRIPTION
## Summary
- adjust PBMon telegram bot to use `wait()` instead of `wait_closed()`

## Testing
- `python -m py_compile PBMon.py`


------
https://chatgpt.com/codex/tasks/task_b_683ad5f4b55483239481695f1adb81b3