### PR TITLE
Fix telegram bot updater wait handling

### DIFF
--- a/PBMon.py
+++ b/PBMon.py
@@ -120,7 +120,10 @@ class PBMon():
             await self.bot_application.initialize()
             await self.bot_application.start()
             await self.bot_application.updater.start_polling()
-            await self.bot_application.updater.wait()
+            if hasattr(self.bot_application.updater, "wait"):
+                await self.bot_application.updater.wait()
+            else:
+                await self.bot_application.updater.wait_closed()
         finally:
             await self.bot_application.stop()
             await self.bot_application.shutdown()


### PR DESCRIPTION
## Summary
- fix PBMon telegram bot updater polling/wait logic

## Testing
- `python -m py_compile PBMon.py`


------
https://chatgpt.com/codex/tasks/task_b_683ada5e2c9083239aeb4586364482ad